### PR TITLE
fix: assert_not_reached in GIArgumentToV8

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -71,6 +71,7 @@ Handle<Value> GIArgumentToV8(Isolate *isolate, GITypeInfo *type_info, GIArgument
             return String::NewFromUtf8 (isolate, data);
         }
 
+    case GI_TYPE_TAG_FILENAME:
     case GI_TYPE_TAG_UTF8:
         if (arg->v_pointer)
             return String::NewFromUtf8 (isolate, (char *) arg->v_pointer);


### PR DESCRIPTION
Filename is said to be encoded in native filesystem encoding, but we can safely assume that it is Utf8, as GLib & Gtk usually do.
