### PR TITLE
classes more conform to standard JS

### DIFF
--- a/examples/hello-gtk.js
+++ b/examples/hello-gtk.js
@@ -3,13 +3,18 @@
 var
   GNode = require('../lib/'),
   Gtk = GNode.importNS('Gtk'),
+  settings,
   win
 ;
 
 GNode.startLoop();
 Gtk.init(null);
 
-console.log(Gtk.Settings.get_default().gtk_enable_accels);
+settings = Gtk.Settings.get_default(),
+settings.gtk_application_prefer_dark_theme = true;
+settings.gtk_theme_name = "Adwaita";
+
+console.log(settings.gtk_enable_accels);
 
 win = new Gtk.Window({
   title: 'node-gtk',

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,8 +38,7 @@ function declareFunction(obj, info) {
     var name = GIRepository.BaseInfo_get_name.call(info);
     var flags = GIRepository.function_info_get_flags(info);
     var func = gi.MakeFunction(info);
-    var target = flags & GIRepository.FunctionInfoFlags.IS_METHOD ?
-        obj.prototype : obj;
+    var target = flags & GIRepository.FunctionInfoFlags.IS_METHOD ? obj.prototype : obj;
     Object.defineProperty(target, name, {
         configurable: true,
         writable: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,10 +38,13 @@ function declareFunction(obj, info) {
     var name = GIRepository.BaseInfo_get_name.call(info);
     var flags = GIRepository.function_info_get_flags(info);
     var func = gi.MakeFunction(info);
-    if (flags & GIRepository.FunctionInfoFlags.IS_METHOD)
-        obj.prototype[name] = func;
-    else
-        obj[name] = func;
+    var target = flags & GIRepository.FunctionInfoFlags.IS_METHOD ?
+        obj.prototype : obj;
+    Object.defineProperty(target, name, {
+        configurable: true,
+        writable: true,
+        value: func
+    });
 }
 
 function makeEnum(info) {
@@ -94,7 +97,7 @@ function makeObject(info) {
         var jsPropertyName = propertyName.replace(/-/g, '_');
 
         Object.defineProperty(constructor.prototype, jsPropertyName, {
-            enumerable: true,
+            configurable: true,
             get: propertyGetter(propertyName),
             set: propertySetter(propertyName),
         });


### PR DESCRIPTION
As discussed in issue #8 the current branch uses JS like descriptors for exported "classes" and their prototype.
