### PR TITLE
avoid multiple export per each module version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,5 @@
-build/Debug
-build/*.Makefile
-build/*.gypi
-build/Makefile
-build/*.mk
+build
 examples
-lib
 node_modules
 .DS_Store
 .gitignore

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+// used to avoid exporting same module
+// every time it's required
+var cache = Object.create(null);
 
 var gi;
 try {
@@ -145,7 +148,9 @@ function importNS(ns, version) {
 }
 
 exports.importNS = function(ns, version) {
-    return importNS(ns, version);
+  var module = cache[ns] || (cache[ns] = {});
+  var ver = version || '*';
+  return module[ver] || (module[ver] = importNS(ns, version));
 };
 
 exports.startLoop = function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,3 @@
-// used to avoid exporting same module
-// every time it's required
-var cache = Object.create(null);
 
 var gi;
 try {
@@ -147,10 +144,12 @@ function importNS(ns, version) {
     return module;
 }
 
+// Used to avoid exporting same module every time it's required
+var cache = Object.create(null);
 exports.importNS = function(ns, version) {
-  var module = cache[ns] || (cache[ns] = {});
-  var ver = version || '*';
-  return module[ver] || (module[ver] = importNS(ns, version));
+    var module = cache[ns] || (cache[ns] = {});
+    var ver = version || '*';
+    return module[ver] || (module[ver] = importNS(ns, version));
 };
 
 exports.startLoop = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-gtk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "GNOME Gtk+ bindings for NodeJS",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Currently, we are repeatedly exporting over and over same module, even if it has been already required elsewhere. This PR ensure every namespace is exported once, improving performance, avoiding duplicated/undesired behaviors (e.g. `GNode.importNS('Gtk') !== GNode.importNS('Gtk')`)
