### PR TITLE
simplified namespace export

### DIFF
--- a/examples/hello-gtk.js
+++ b/examples/hello-gtk.js
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
 var
-  GNode = require('../lib/'),
-  Gtk = GNode.importNS('Gtk'),
+  Gtk = require('../lib/')('Gtk'),
   settings,
   win
 ;
 
-GNode.startLoop();
 Gtk.init(null);
 
 settings = Gtk.Settings.get_default(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 
 var gi;
+var initLoop = true;
 try {
     gi = require('../build/Release/node-gtk');
 } catch(e) {
@@ -144,10 +145,18 @@ function importNS(ns, version) {
     return module;
 }
 
-exports.importNS = function(ns, version) {
+module.exports = function nodeGTK(ns, version) {
+  if (initLoop) {
+    initLoop = false;
+    nodeGTK.startLoop();
+  }
+  return nodeGTK.importNS(ns, version);
+};
+
+module.exports.importNS = function(ns, version) {
     return importNS(ns, version);
 };
 
-exports.startLoop = function() {
+module.exports.startLoop = function() {
     gi.StartLoop();
 };


### PR DESCRIPTION
As previously requested from a user, the module could simplify its default export and take implicitly care of the `gi.StartLoop()` call.

This PR makes it possibl eto just include `Gtk` via `var Gtk = require('../lib/')('Gtk')` without needing to import a namespace and call a `startLoop` which might result unfamiliar for regular nodejs developers.
