### PR TITLE
Using withCamelCase method to pollute namespaces

### DIFF
--- a/examples/hello-gtk-cc.js
+++ b/examples/hello-gtk-cc.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 var
-  GNode = require('../lib/'),
-  Gtk = GNode.withCamelCase('Gtk'),
-  settings,
-  win
+    GNode = require('../lib/'),
+    Gtk = GNode.withCamelCase('Gtk'),
+    settings,
+    win
 ;
 
 GNode.startLoop();
@@ -17,9 +17,10 @@ settings.gtkThemeName = "Adwaita";
 console.log(settings.gtkEnableAccels);
 
 win = new Gtk.Window({
-  title: 'node-gtk'
-  // __init__ not implemented yet
-  // , window_position: Gtk.WindowPosition.CENTER
+    title: 'node-gtk',
+    // __init__ not implemented yet
+    // so the following cannot be windowPosition yet
+    window_position: Gtk.WindowPosition.CENTER
 });
 
 win.connect('show', Gtk.main);

--- a/examples/hello-gtk-cc.js
+++ b/examples/hello-gtk-cc.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+var
+  GNode = require('../lib/'),
+  Gtk = GNode.withCamelCase('Gtk'),
+  settings,
+  win
+;
+
+GNode.startLoop();
+Gtk.init(null);
+
+settings = Gtk.Settings.getDefault(),
+settings.gtkApplicationPreferDarkTheme = true;
+settings.gtkThemeName = "Adwaita";
+
+console.log(settings.gtkEnableAccels);
+
+win = new Gtk.Window({
+  title: 'node-gtk'
+  // __init__ not implemented yet
+  // , window_position: Gtk.WindowPosition.CENTER
+});
+
+win.connect('show', Gtk.main);
+win.connect('destroy', Gtk.mainQuit);
+
+win.setDefaultSize(200, 80);
+win.add(new Gtk.Label({label: 'Hello Gtk+'}));
+
+win.showAll();

--- a/examples/hello-gtk.js
+++ b/examples/hello-gtk.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 var
-  GNode = require('../lib/'),
-  Gtk = GNode.importNS('Gtk'),
-  settings,
-  win
+    GNode = require('../lib/'),
+    Gtk = GNode.importNS('Gtk'),
+    settings,
+    win
 ;
 
 GNode.startLoop();
@@ -17,8 +17,8 @@ settings.gtk_theme_name = "Adwaita";
 console.log(settings.gtk_enable_accels);
 
 win = new Gtk.Window({
-  title: 'node-gtk',
-  window_position: Gtk.WindowPosition.CENTER
+    title: 'node-gtk',
+    window_position: Gtk.WindowPosition.CENTER
 });
 
 win.connect('show', Gtk.main);

--- a/examples/test-cc.js
+++ b/examples/test-cc.js
@@ -1,0 +1,24 @@
+
+const GNode = require('../lib/');
+GNode.startLoop();
+
+const GLib = GNode.withCamelCase("GLib");
+console.log(GLib.asciiStrup("foo", -1));
+
+const GUdev = GNode.withCamelCase("GUdev");
+var client = new GUdev.Client();
+var obj = client.queryByDeviceFile("/dev/dri/card0");
+console.log(obj.getName());
+
+console.log(GLib.test_override());
+
+const Gtk = GNode.withCamelCase("Gtk");
+Gtk.init(null);
+
+var w = new Gtk.Window();
+var b = new Gtk.Button({ label: "Hi!" });
+b.connect('clicked', function() { console.log("BB"); });
+w.add(b);
+w.showAll();
+
+Gtk.main();

--- a/lib/camel-case.js
+++ b/lib/camel-case.js
@@ -1,3 +1,4 @@
+// Reserved name for Classes prototypes
 var INITIALIZER = '__init__';
 
 function isPlainObject(obj) {
@@ -39,7 +40,7 @@ function wrapInitializer(init) {
     };
 }
 
-exports.withCamelCase = function withCamelCase(ns) {
+function withCamelCase(ns) {
     var descriptors = {};
     var is_python_case = /[a-z]_[a-z]/;
     var isConstructor = /^[A-Z]/;
@@ -60,4 +61,9 @@ exports.withCamelCase = function withCamelCase(ns) {
         }
     });
     return Object.defineProperties(ns, descriptors);
+}
+
+var cache = new WeakMap;
+exports.withCamelCase = function(ns) {
+    return cache.get(ns) || cache.set(ns, withCamelCase(ns)).get(ns);
 };

--- a/lib/camel-case.js
+++ b/lib/camel-case.js
@@ -4,18 +4,6 @@ function isPlainObject(obj) {
     return Object.getPrototypeOf(obj) === Object.prototype;
 }
 
-function propertyGetter(key) {
-    return function get() {
-        return this[key];
-    };
-}
-
-function propertySetter(key) {
-    return function set(value) {
-        this[key] = value;
-    };
-}
-
 function to_python_case(key) {
     return key.replace(/([a-z])([A-Z]+)/g, function ($0, $1, $2) {
         return $1 + '_' + $2.toLowerCase();
@@ -60,12 +48,7 @@ exports.withCamelCase = function withCamelCase(ns) {
         var isDataDescriptor = descriptor.hasOwnProperty('value');
         var isFunction = isDataDescriptor && typeof descriptor.value === 'function';
         if (is_python_case.test(key)) {
-            descriptors[toCamelCase(key)] = isFunction ? descriptor : {
-                configurable: descriptor.configurable,
-                enumerable: descriptor.enumerable,
-                get: propertyGetter(key),
-                set: propertySetter(key)
-            };
+            descriptors[toCamelCase(key)] = descriptor;
         } else if (isFunction) {
             if (key === INITIALIZER) {
                 descriptor.value = wrapInitializer(descriptor.value);

--- a/lib/camel-case.js
+++ b/lib/camel-case.js
@@ -1,0 +1,80 @@
+var INITIALIZER = '__init__';
+
+function isPlainObject(obj) {
+    return Object.getPrototypeOf(obj) === Object.prototype;
+}
+
+function propertyGetter(key) {
+    return function get() {
+        return this[key];
+    };
+}
+
+function propertySetter(key) {
+    return function set(value) {
+        this[key] = value;
+    };
+}
+
+function to_python_case(key) {
+    return key.replace(/([a-z])([A-Z]+)/g, function ($0, $1, $2) {
+        return $1 + '_' + $2.toLowerCase();
+    });
+}
+
+function toCamelCase(key) {
+    return key.replace(/[_-]([a-z])/g, function ($0, $1) {
+        return $1.toUpperCase();
+    });
+}
+
+function withoutCamelCase(obj) {
+    var out = {}, key;
+    for (key in obj) {
+        out[to_python_case(key)] = obj[key];
+    }
+    return out;
+}
+
+function wrapInitializer(init) {
+    return function () {
+        for (var
+            tmp,
+            length = arguments.length,
+            args = [],
+            i = 0; i < length; i++
+        ) {
+            tmp = arguments[i];
+            args[i] = isPlainObject(tmp) ? withoutCamelCase(tmp) : tmp;
+        }
+        init.apply(this, args);
+    };
+}
+
+exports.withCamelCase = function withCamelCase(ns) {
+    var descriptors = {};
+    var is_python_case = /[a-z]_[a-z]/;
+    var isConstructor = /^[A-Z]/;
+    Object.getOwnPropertyNames(ns).forEach(function (key) {
+        var descriptor = Object.getOwnPropertyDescriptor(ns, key);
+        var isDataDescriptor = descriptor.hasOwnProperty('value');
+        var isFunction = isDataDescriptor && typeof descriptor.value === 'function';
+        if (is_python_case.test(key)) {
+            descriptors[toCamelCase(key)] = isFunction ? descriptor : {
+                configurable: descriptor.configurable,
+                enumerable: descriptor.enumerable,
+                get: propertyGetter(key),
+                set: propertySetter(key)
+            };
+        } else if (isFunction) {
+            if (key === INITIALIZER) {
+                descriptor.value = wrapInitializer(descriptor.value);
+                descriptors[key] = descriptor;
+            } else if (isConstructor.test(key)) {
+                withCamelCase(descriptor.value);
+                withCamelCase(descriptor.value.prototype);
+            }
+        }
+    });
+    return Object.defineProperties(ns, descriptors);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,3 +151,8 @@ exports.importNS = function(ns, version) {
 exports.startLoop = function() {
     gi.StartLoop();
 };
+
+var cc = require('./camel-case');
+exports.withCamelCase = function (ns) {
+    return cc.withCamelCase(typeof ns === 'string' ? importNS(ns) : ns);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,5 +158,5 @@ exports.startLoop = function() {
 
 var cc = require('./camel-case');
 exports.withCamelCase = function (ns) {
-    return cc.withCamelCase(typeof ns === 'string' ? importNS(ns) : ns);
+    return cc.withCamelCase(typeof ns === 'string' ? exports.importNS(ns) : ns);
 };


### PR DESCRIPTION
As discussed in issue #9 we'd like to experiment with a method capable of polluting namespaces when required.

Ideally this needs to be updated and properly integrated with [this PR](https://github.com/WebReflection/node-gtk/pull/15) (once and if ever accepted) because we surely don't want to ever wrap or redefine twice a single native property, method, or initializer.

The current proposal uses a well known naming convention in JS for the initializer method, here called `__init__` and such name is defined on top of the file so we might eventually change it later on if we think we need that.

At this point, all a constructor needs to do is to export through its prototype the initial `__init__` method so that we don't need to swap any constructor and we can trust the wrap for the only initializer.

Example

``` js
// new exported logic
Gtk.Window = function Window() {
  this.__init__.apply(this, arguments);
};

// native code as initializer
Object.defineProperty(Gtk.Window.prototype, '__init__', {
  configurable: true,
  value: function __init__() {
    // something similar to the following
    gi.nativeInitializer.apply(this, arguments);
  }
});

```

Once above code is in place it will be possible to pass objects with camelCase properties so that these will be normalized into a new object as python_case and the original/native initialization would be triggered and work without issues.
