### PR TITLE
move away from deprecated APIs

### DIFF
--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -12,7 +12,7 @@ struct Boxed {
 
 static G_DEFINE_QUARK(gnode_js_template, gnode_js_template);
 
-static void BoxedClassDestroyed(const WeakCallbackData<FunctionTemplate, GIBaseInfo> &data) {
+static void BoxedClassDestroyed(const WeakCallbackInfo<GIBaseInfo> &data) {
     GIBaseInfo *info = data.GetParameter ();
     GType gtype = g_registered_type_info_get_g_type ((GIRegisteredTypeInfo *) info);
 
@@ -66,7 +66,7 @@ static Local<FunctionTemplate> GetBoxedTemplate(Isolate *isolate, GIBaseInfo *in
         Local<FunctionTemplate> tpl = FunctionTemplate::New (isolate, BoxedConstructor, External::New (isolate, info));
 
         Persistent<FunctionTemplate> *persistent = new Persistent<FunctionTemplate>(isolate, tpl);
-        persistent->SetWeak (g_base_info_ref (info), BoxedClassDestroyed);
+        persistent->SetWeak (g_base_info_ref (info), BoxedClassDestroyed, v8::WeakCallbackType::kParameter);
 
         const char *class_name = g_base_info_get_name (info);
         tpl->SetClassName (String::NewFromUtf8 (isolate, class_name));
@@ -94,8 +94,14 @@ Local<Value> WrapperFromBoxed(Isolate *isolate, GIBaseInfo *info, void *data) {
     Local<Function> constructor = MakeBoxed (isolate, info);
 
     Local<Value> boxed_external = External::New (isolate, data);
+    Local<Context> context = Context::New (isolate);
     Local<Value> args[] = { boxed_external };
-    Local<Object> obj = constructor->NewInstance (1, args);
+    Local<Object> obj;
+    MaybeLocal<Object> mobj = constructor->NewInstance (context, 1, args);
+    bool checkme = mobj.ToLocal(&obj);
+
+    if (!checkme) { /* TODO: check this boolean value and do something */ }
+
     return obj;
 }
 

--- a/src/function.cc
+++ b/src/function.cc
@@ -164,7 +164,7 @@ static void FunctionInvoker(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue ().Set (GIArgumentToV8 (isolate, &return_value_type, &return_value));
 }
 
-static void FunctionDestroyed(const WeakCallbackData<FunctionTemplate, FunctionInfo> &data) {
+static void FunctionDestroyed(const WeakCallbackInfo<FunctionInfo> &data) {
     FunctionInfo *func = data.GetParameter ();
     g_base_info_unref (func->info);
     g_function_invoker_destroy (&func->invoker);
@@ -181,7 +181,7 @@ Local<Function> MakeFunction(Isolate *isolate, GIBaseInfo *info) {
     Local<Function> fn = tpl->GetFunction ();
 
     Persistent<FunctionTemplate> persistent(isolate, tpl);
-    persistent.SetWeak (func, FunctionDestroyed);
+    persistent.SetWeak (func, FunctionDestroyed, v8::WeakCallbackType::kParameter);
 
     const char *function_name = g_base_info_get_name (info);
     fn->SetName (String::NewFromUtf8 (isolate, function_name));

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -133,13 +133,13 @@ static void SignalConnect(const FunctionCallbackInfo<Value> &args) {
 static Local<FunctionTemplate> GetBaseClassTemplate(Isolate *isolate) {
     Local<FunctionTemplate> tpl = FunctionTemplate::New (isolate);
     Local<ObjectTemplate> proto = tpl->PrototypeTemplate ();
-    proto->Set (String::NewFromUtf8 (isolate, "connect"), FunctionTemplate::New (isolate, SignalConnect)->GetFunction ());
+    proto->Set (String::NewFromUtf8 (isolate, "connect"), FunctionTemplate::New (isolate, SignalConnect));
     return tpl;
 }
 
 static Local<FunctionTemplate> GetClassTemplateFromGI(Isolate *isolate, GIBaseInfo *info);
 
-static void ClassDestroyed(const WeakCallbackData<FunctionTemplate, GIBaseInfo> &data) {
+static void ClassDestroyed(const WeakCallbackInfo<GIBaseInfo> &data) {
     GIBaseInfo *info = data.GetParameter ();
     GType gtype = g_registered_type_info_get_g_type ((GIRegisteredTypeInfo *) info);
 
@@ -163,7 +163,7 @@ static Local<FunctionTemplate> GetClassTemplate(Isolate *isolate, GIBaseInfo *in
         Local<FunctionTemplate> tpl = FunctionTemplate::New (isolate, GObjectConstructor, External::New (isolate, info));
 
         Persistent<FunctionTemplate> *persistent = new Persistent<FunctionTemplate>(isolate, tpl);
-        persistent->SetWeak (g_base_info_ref (info), ClassDestroyed);
+        persistent->SetWeak (g_base_info_ref (info), ClassDestroyed, v8::WeakCallbackType::kParameter);
         g_type_set_qdata (gtype, gnode_js_template_quark (), persistent);
 
         const char *class_name = g_base_info_get_name (info);
@@ -199,7 +199,7 @@ Local<Function> MakeClass(Isolate *isolate, GIBaseInfo *info) {
     return tpl->GetFunction ();
 }
 
-static void ObjectDestroyed(const WeakCallbackData<Object, GObject> &data) {
+static void ObjectDestroyed(const WeakCallbackInfo<GObject> &data) {
     GObject *gobject = data.GetParameter ();
 
     void *type_data = g_object_get_qdata (gobject, gnode_js_object_quark ());
@@ -223,7 +223,7 @@ static void ToggleNotify(gpointer user_data, GObject *gobject, gboolean toggle_d
     if (toggle_down) {
         /* We're dropping from 2 refs to 1 ref. We are the last holder. Make
          * sure that that our weak ref is installed. */
-        persistent->SetWeak (gobject, ObjectDestroyed);
+        persistent->SetWeak (gobject, ObjectDestroyed, v8::WeakCallbackType::kParameter);
     } else {
         /* We're going from 1 ref to 2 refs. We can't let our wrapper be
          * collected, so make sure that our reference is persistent */
@@ -244,10 +244,16 @@ Local<Value> WrapperFromGObject(Isolate *isolate, GObject *gobject) {
 
         Local<FunctionTemplate> tpl = GetClassTemplateFromGType (isolate, gtype);
         Local<Function> constructor = tpl->GetFunction ();
+        Local<Context> context = Context::New (isolate);
 
         Local<Value> gobject_external = External::New (isolate, gobject);
         Local<Value> args[] = { gobject_external };
-        Local<Object> obj = constructor->NewInstance (1, args);
+        Local<Object> obj;
+        MaybeLocal<Object> mobj = constructor->NewInstance (context, 1, args);
+        bool checkme = mobj.ToLocal(&obj);
+
+        if (!checkme) {/* TODO: Check this boolean */ }
+
         return obj;
     }
 }


### PR DESCRIPTION
This fix warnings that prevent building on `nodejs v6` (because `-Werror`).

Please note that there's a TODO in `WrapperFromBoxed` and `WrapperFromGObject`, perhaps check the `checkme` variable or `MaybeLocal::IsEmpty()`, I don't know how to do "right" so let it as is...
